### PR TITLE
Trying to make Taro regrow a bit slower and Ferns quicker

### DIFF
--- a/Defs/ThingDefs_Plants/Plants_Tropical.xml
+++ b/Defs/ThingDefs_Plants/Plants_Tropical.xml
@@ -73,7 +73,7 @@
       <harvestedThingDef>TaroRoot</harvestedThingDef>
       <harvestWork>250</harvestWork>
       <fertilityMin>0.2</fertilityMin>
-      <wildCommonalityMaxFraction>2.0</wildCommonalityMaxFraction>
+      <!-- <wildCommonalityMaxFraction>2.0</wildCommonalityMaxFraction> -->
       <sowTags>
         <li>Ground</li>
         <li>Hydroponic</li>
@@ -173,6 +173,7 @@
       <seedEmitMTBDays>3.5</seedEmitMTBDays>
       <fertilityFactorGrowthRate>0.90</fertilityFactorGrowthRate>
       <fertilityFactorPlantChance>0.90</fertilityFactorPlantChance>
+      <wildCommonalityMaxFraction>2.0</wildCommonalityMaxFraction>
     </plant>
   </ThingDef>
 


### PR DESCRIPTION
I noticed that Taro is regrowing way more quicker than Ferns. That don't seems right/logic to me.       

![regrow](http://i.imgur.com/SF1DFtC.jpg)
_Screenshot taken after several Toxic-Fallout - Taro everywhere_

In the code I found `<wildCommonalityMaxFraction>` set to **2** for Taro (seems to mean that the game permit 2 times more Taro than other - _I propose to put that attribute to Ferns_)
